### PR TITLE
fix: deadlock in agents map => move agents map to separted struct AgentStorage for avoiding block

### DIFF
--- a/crates/relayer/src/agent_store.rs
+++ b/crates/relayer/src/agent_store.rs
@@ -1,0 +1,43 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use async_std::channel::Sender;
+
+use crate::ProxyTunnel;
+
+#[derive(Clone)]
+pub struct AgentStore {
+    agents: Arc<RwLock<HashMap<u64, Sender<Box<dyn ProxyTunnel>>>>>,
+}
+
+impl AgentStore {
+    pub fn new() -> Self {
+        Self {
+            agents: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub fn add(&self, id: u64, tx: Sender<Box<dyn ProxyTunnel>>) {
+        self.agents
+            .write()
+            .expect("Should write agents")
+            .insert(id, tx);
+    }
+
+    pub fn get(&self, id: u64) -> Option<Sender<Box<dyn ProxyTunnel>>> {
+        self.agents
+            .read()
+            .expect("Should write agents")
+            .get(&id)
+            .cloned()
+    }
+
+    pub fn remove(&self, id: u64) {
+        self.agents
+            .write()
+            .expect("Should write agents")
+            .remove(&id);
+    }
+}

--- a/crates/relayer/src/main.rs
+++ b/crates/relayer/src/main.rs
@@ -1,7 +1,8 @@
 use atm0s_reverse_proxy_relayer::{
     run_agent_connection, run_sdn, tunnel_task, AgentIncommingConnHandlerDummy, AgentListener,
-    AgentQuicListener, AgentTcpListener, ProxyHttpListener, ProxyListener, TunnelContext,
-    METRICS_AGENT_COUNT, METRICS_AGENT_LIVE, METRICS_PROXY_COUNT, METRICS_PROXY_LIVE,
+    AgentQuicListener, AgentStore, AgentTcpListener, ProxyHttpListener, ProxyListener,
+    TunnelContext, METRICS_AGENT_COUNT, METRICS_AGENT_LIVE, METRICS_PROXY_COUNT,
+    METRICS_PROXY_LIVE,
 };
 use atm0s_sdn::{NodeAddr, NodeId};
 use clap::Parser;
@@ -105,7 +106,7 @@ async fn main() {
     let mut proxy_tls_listener = ProxyHttpListener::new(args.https_port, true)
         .await
         .expect("Should listen tls port");
-    let agents = Arc::new(RwLock::new(HashMap::new()));
+    let agents = AgentStore::new();
 
     #[cfg(feature = "expose-metrics")]
     let app = Route::new()


### PR DESCRIPTION
Current agents lock is potential deadlock if get and keep lifecycle. Trying to fix it by move to AgentStorage to separated rwlock calling