### PR TITLE
fix: remove spawn task in run_agent_connection

### DIFF
--- a/crates/relayer/src/lib.rs
+++ b/crates/relayer/src/lib.rs
@@ -88,23 +88,21 @@ pub async fn run_agent_connection<AG, S, R, W>(
     agents.add(home_id.clone(), proxy_tunnel_tx);
     node_alias_sdk.register_alias(home_id.clone()).await;
     let agents = agents.clone();
-    async_std::task::spawn(async move {
-        gauge!(METRICS_AGENT_LIVE).increment(1.0);
-        log::info!("agent_worker run for domain: {}", domain);
-        loop {
-            match agent_worker.run().await {
-                Ok(()) => {}
-                Err(e) => {
-                    log::error!("agent_worker error: {}", e);
-                    break;
-                }
+    gauge!(METRICS_AGENT_LIVE).increment(1.0);
+    log::info!("agent_worker run for domain: {}", domain);
+    loop {
+        match agent_worker.run().await {
+            Ok(()) => {}
+            Err(e) => {
+                log::error!("agent_worker error: {}", e);
+                break;
             }
         }
-        agents.remove(home_id);
-        node_alias_sdk
-            .unregister_alias(home_id_from_domain(&domain))
-            .await;
-        log::info!("agent_worker exit for domain: {}", domain);
-        gauge!(METRICS_AGENT_LIVE).decrement(1.0);
-    });
+    }
+    agents.remove(home_id);
+    node_alias_sdk
+        .unregister_alias(home_id_from_domain(&domain))
+        .await;
+    log::info!("agent_worker exit for domain: {}", domain);
+    gauge!(METRICS_AGENT_LIVE).decrement(1.0);
 }

--- a/crates/relayer/src/main.rs
+++ b/crates/relayer/src/main.rs
@@ -232,7 +232,12 @@ async fn main() {
         select! {
             e = quic_agent_listener.recv().fuse() => match e {
                 Ok(agent_connection) => {
-                    run_agent_connection(agent_connection, agents.clone(), alias_sdk.clone(), agent_rpc_handler_quic.clone()).await;
+                    let agents1 = agents.clone();
+                    let alias_sdk1 = alias_sdk.clone();
+                    let agent_rpc_handler_quic1 = agent_rpc_handler_quic.clone();
+                    async_std::task::spawn(async move {
+                        run_agent_connection(agent_connection, agents1, alias_sdk1, agent_rpc_handler_quic1).await;
+                    });
                 }
                 Err(e) => {
                     log::error!("agent_listener error {}", e);
@@ -241,7 +246,12 @@ async fn main() {
             },
             e = tcp_agent_listener.recv().fuse() => match e {
                 Ok(agent_connection) => {
-                    run_agent_connection(agent_connection, agents.clone(), alias_sdk.clone(), agent_rpc_handler_tcp.clone()).await;
+                    let agents1 = agents.clone();
+                    let alias_sdk1 = alias_sdk.clone();
+                    let agent_rpc_handler_tcp1 = agent_rpc_handler_tcp.clone();
+                    async_std::task::spawn(async move {
+                        run_agent_connection(agent_connection, agents1, alias_sdk1, agent_rpc_handler_tcp1).await;
+                    });
                 }
                 Err(e) => {
                     log::error!("agent_listener error {}", e);


### PR DESCRIPTION
There is no need to spawn a task in the function `run_agent_connection` function. The loop is to do nothing; its responsibility is to keep the connection and break when the agent is disconnected. So, I want to remove the spawn and move it to outside. The outside also has to know when the agent is disconnected