### PR TITLE
fix: tunnel stuck

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rcgen = "0.13"
 url = "2.5"
 base64 = "0.22"
 local-ip-address = "0.6"
+derive_more = "1.0"
 
 [profile.release]
 strip = true  # Automatically strip symbols from the binary.

--- a/crates/agent/examples/benchmark_clients.rs
+++ b/crates/agent/examples/benchmark_clients.rs
@@ -10,7 +10,6 @@ use atm0s_reverse_proxy_agent::{
 };
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use clap::Parser;
-use futures::{AsyncRead, AsyncWrite};
 use protocol::DEFAULT_TUNNEL_CERT;
 use protocol_ed25519::AgentLocalKey;
 use rustls::pki_types::CertificateDer;
@@ -153,13 +152,11 @@ async fn connect(client: usize, args: Args, registry: Arc<dyn ServiceRegistry>) 
     }
 }
 
-async fn run_connection_loop<S, R, W>(
-    mut connection: impl Connection<S, R, W>,
+async fn run_connection_loop<S>(
+    mut connection: impl Connection<S>,
     registry: Arc<dyn ServiceRegistry>,
 ) where
-    S: SubConnection<R, W> + 'static,
-    R: AsyncRead + Send + Unpin + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
+    S: SubConnection + 'static,
 {
     loop {
         match connection.recv().await {

--- a/crates/agent/src/connection.rs
+++ b/crates/agent/src/connection.rs
@@ -4,6 +4,7 @@ use std::error::Error;
 
 use clap::ValueEnum;
 use futures::{AsyncRead, AsyncWrite};
+use protocol::stream::NamedStream;
 
 pub mod quic;
 pub mod tcp;
@@ -14,14 +15,10 @@ pub enum Protocol {
     Quic,
 }
 
-pub trait SubConnection<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>: Send + Sync {
-    fn split(self) -> (R, W);
-}
+pub trait SubConnection: AsyncRead + AsyncWrite + NamedStream + Unpin + Send + Sync {}
 
 #[async_trait::async_trait]
-pub trait Connection<S: SubConnection<R, W>, R: AsyncRead + Unpin, W: AsyncWrite + Unpin>:
-    Send + Sync
-{
+pub trait Connection<S: SubConnection>: Send + Sync {
     async fn create_outgoing(&mut self) -> Result<S, Box<dyn Error>>;
     async fn recv(&mut self) -> Result<S, Box<dyn Error>>;
 }

--- a/crates/agent/src/connection/quic/helper.rs
+++ b/crates/agent/src/connection/quic/helper.rs
@@ -1,0 +1,79 @@
+use rustls::{client::danger::ServerCertVerifier, pki_types::CertificateDer};
+use std::{error::Error, sync::Arc, time::Duration};
+
+use quinn::{crypto::rustls::QuicClientConfig, ClientConfig, TransportConfig};
+
+pub fn configure_client(
+    server_certs: &[CertificateDer],
+    allow_quic_insecure: bool,
+) -> Result<ClientConfig, Box<dyn Error>> {
+    let mut config = if allow_quic_insecure {
+        let provider = rustls::crypto::CryptoProvider::get_default().unwrap();
+        ClientConfig::new(Arc::new(QuicClientConfig::try_from(
+            rustls::ClientConfig::builder()
+                .dangerous()
+                .with_custom_certificate_verifier(SkipServerVerification::new(provider.clone()))
+                .with_no_client_auth(),
+        )?))
+    } else {
+        let mut certs = rustls::RootCertStore::empty();
+        for cert in server_certs {
+            certs.add(cert.clone())?;
+        }
+        ClientConfig::with_root_certificates(Arc::new(certs))?
+    };
+
+    let mut transport = TransportConfig::default();
+    transport.keep_alive_interval(Some(Duration::from_secs(15)));
+    transport.max_idle_timeout(Some(
+        Duration::from_secs(30)
+            .try_into()
+            .expect("Should config timeout"),
+    ));
+    config.transport_config(Arc::new(transport));
+    Ok(config)
+}
+
+#[derive(Debug)]
+struct SkipServerVerification(Arc<rustls::crypto::CryptoProvider>);
+
+impl SkipServerVerification {
+    fn new(provider: Arc<rustls::crypto::CryptoProvider>) -> Arc<Self> {
+        Arc::new(Self(provider))
+    }
+}
+
+impl ServerCertVerifier for SkipServerVerification {
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+}

--- a/crates/agent/src/connection/quic/sub_conn.rs
+++ b/crates/agent/src/connection/quic/sub_conn.rs
@@ -37,6 +37,9 @@ impl AsyncRead for QuicSubConnection {
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
         match this.recv.poll_read(cx, buf) {
+            // TODO: refactor
+            // Quinn seems to have some issue with close connection. the Writer side already close but
+            // Reader side only fire bellow error
             Poll::Ready(Err(quinn::ReadError::ConnectionLost(
                 ConnectionError::ConnectionClosed(_),
             ))) => Poll::Ready(Ok(0)),

--- a/crates/agent/src/connection/quic/sub_conn.rs
+++ b/crates/agent/src/connection/quic/sub_conn.rs
@@ -1,0 +1,69 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{AsyncRead, AsyncWrite};
+use protocol::stream::NamedStream;
+use quinn::{ConnectionError, RecvStream, SendStream};
+
+use crate::SubConnection;
+
+pub struct QuicSubConnection {
+    send: SendStream,
+    recv: RecvStream,
+}
+
+impl QuicSubConnection {
+    pub fn new(send: SendStream, recv: RecvStream) -> Self {
+        Self { send, recv }
+    }
+}
+
+impl SubConnection for QuicSubConnection {}
+
+impl NamedStream for QuicSubConnection {
+    fn name(&self) -> &'static str {
+        "outgoing-sdn-quic-tunnel"
+    }
+}
+
+impl AsyncRead for QuicSubConnection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        match this.recv.poll_read(cx, buf) {
+            Poll::Ready(Err(quinn::ReadError::ConnectionLost(
+                ConnectionError::ConnectionClosed(_),
+            ))) => Poll::Ready(Ok(0)),
+            e => e.map_err(|e| e.into()),
+        }
+    }
+}
+
+impl AsyncWrite for QuicSubConnection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.send)
+            .poll_write(cx, buf)
+            .map_err(|e| e.into())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.send).poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.send).poll_close(cx)
+    }
+}

--- a/crates/agent/src/connection/quic/sub_conn.rs
+++ b/crates/agent/src/connection/quic/sub_conn.rs
@@ -25,7 +25,7 @@ impl SubConnection for QuicSubConnection {}
 
 impl NamedStream for QuicSubConnection {
     fn name(&self) -> &'static str {
-        "outgoing-sdn-quic-tunnel"
+        "out-proxy-quic-tunnel"
     }
 }
 
@@ -41,7 +41,7 @@ impl AsyncRead for QuicSubConnection {
             // Quinn seems to have some issue with close connection. the Writer side already close but
             // Reader side only fire bellow error
             Poll::Ready(Err(quinn::ReadError::ConnectionLost(
-                ConnectionError::ConnectionClosed(_),
+                ConnectionError::ApplicationClosed(_),
             ))) => Poll::Ready(Ok(0)),
             e => e.map_err(|e| e.into()),
         }

--- a/crates/agent/src/connection/tcp/sub_conn.rs
+++ b/crates/agent/src/connection/tcp/sub_conn.rs
@@ -1,0 +1,56 @@
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::{AsyncRead, AsyncWrite};
+use protocol::stream::NamedStream;
+
+use crate::SubConnection;
+
+pub struct TcpSubConnection {
+    stream: yamux::Stream,
+}
+
+impl From<yamux::Stream> for TcpSubConnection {
+    fn from(stream: yamux::Stream) -> Self {
+        Self { stream }
+    }
+}
+
+impl SubConnection for TcpSubConnection {}
+
+impl NamedStream for TcpSubConnection {
+    fn name(&self) -> &'static str {
+        "yamux-tcp"
+    }
+}
+
+impl AsyncRead for TcpSubConnection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for TcpSubConnection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.get_mut().stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().stream).poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.get_mut().stream).poll_flush(cx)
+    }
+}

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use local_tunnel::tcp::LocalTcpTunnel;
 use protocol::{
     cluster::{wait_object, AgentTunnelRequest},
     stream::pipeline_streams,
@@ -14,7 +13,9 @@ pub use connection::{
     tcp::{TcpConnection, TcpSubConnection},
     Connection, Protocol, SubConnection,
 };
-pub use local_tunnel::{registry::SimpleServiceRegistry, LocalTunnel, ServiceRegistry};
+pub use local_tunnel::{
+    registry::SimpleServiceRegistry, tcp::LocalTcpTunnel, LocalTunnel, ServiceRegistry,
+};
 
 pub async fn run_tunnel_connection<S>(
     mut incoming_proxy_conn: S,
@@ -37,7 +38,7 @@ pub async fn run_tunnel_connection<S>(
                     registry.dest_for(handshake.tls, handshake.service, &handshake.domain)
                 {
                     log::info!("create tunnel to dest {}", dest);
-                    LocalTcpTunnel::new(dest).await
+                    LocalTcpTunnel::connect(dest).await
                 } else {
                     log::warn!(
                         "dest for service {:?} tls {} domain {} not found",

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use local_tunnel::tcp::LocalTcpTunnel;
-use protocol::cluster::{wait_object, AgentTunnelRequest};
-
-use crate::local_tunnel::LocalTunnel;
+use protocol::{
+    cluster::{wait_object, AgentTunnelRequest},
+    stream::pipeline_streams,
+};
 
 mod connection;
 mod local_tunnel;
@@ -14,45 +14,45 @@ pub use connection::{
     tcp::{TcpConnection, TcpSubConnection},
     Connection, Protocol, SubConnection,
 };
-pub use local_tunnel::{registry::SimpleServiceRegistry, ServiceRegistry};
+pub use local_tunnel::{registry::SimpleServiceRegistry, LocalTunnel, ServiceRegistry};
 
-pub async fn run_tunnel_connection<S, R, W>(sub_connection: S, registry: Arc<dyn ServiceRegistry>)
-where
-    S: SubConnection<R, W> + 'static,
-    R: AsyncRead + Send + Unpin,
-    W: AsyncWrite + Send + Unpin,
+pub async fn run_tunnel_connection<S>(
+    mut incoming_proxy_conn: S,
+    registry: Arc<dyn ServiceRegistry>,
+) where
+    S: SubConnection,
 {
     log::info!("sub_connection pipe to local_tunnel start");
-    let (mut reader1, mut writer1) = sub_connection.split();
 
-    let local_tunnel = match wait_object::<_, AgentTunnelRequest, 1000>(&mut reader1).await {
-        Ok(handshake) => {
-            log::info!(
-                "sub_connection pipe with handshake: tls: {}, {}/{:?} ",
-                handshake.tls,
-                handshake.domain,
-                handshake.service
-            );
-            if let Some(dest) =
-                registry.dest_for(handshake.tls, handshake.service, &handshake.domain)
-            {
-                log::info!("create tunnel to dest {}", dest);
-                LocalTcpTunnel::new(dest).await
-            } else {
-                log::warn!(
-                    "dest for service {:?} tls {} domain {} not found",
-                    handshake.service,
+    let local_tunnel =
+        match wait_object::<_, AgentTunnelRequest, 1000>(&mut incoming_proxy_conn).await {
+            Ok(handshake) => {
+                log::info!(
+                    "sub_connection pipe with handshake: tls: {}, {}/{:?} ",
                     handshake.tls,
-                    handshake.domain
+                    handshake.domain,
+                    handshake.service
                 );
+                if let Some(dest) =
+                    registry.dest_for(handshake.tls, handshake.service, &handshake.domain)
+                {
+                    log::info!("create tunnel to dest {}", dest);
+                    LocalTcpTunnel::new(dest).await
+                } else {
+                    log::warn!(
+                        "dest for service {:?} tls {} domain {} not found",
+                        handshake.service,
+                        handshake.tls,
+                        handshake.domain
+                    );
+                    return;
+                }
+            }
+            Err(e) => {
+                log::error!("read first pkt error: {}", e);
                 return;
             }
-        }
-        Err(e) => {
-            log::error!("read first pkt error: {}", e);
-            return;
-        }
-    };
+        };
 
     let local_tunnel = match local_tunnel {
         Ok(local_tunnel) => local_tunnel,
@@ -62,35 +62,14 @@ where
         }
     };
 
-    let (mut reader2, mut writer2) = local_tunnel.split();
-    let job1 = async {
-        log::info!("task1 start");
-        let res = futures::io::copy(&mut reader1, &mut writer2).await;
-        writer2.flush().await;
-        writer2.close().await;
-        log::info!("task1 end {res:?}");
-        res
-    };
-    let job2 = async {
-        log::info!("task2 start");
-        let res = futures::io::copy(&mut reader2, &mut writer1).await;
-        writer1.flush().await;
-        writer1.close().await;
-        log::info!("task2 end {res:?}");
-        res
-    };
+    log::info!("sub_connection pipe to local_tunnel start");
 
-    let (res1, res2) = futures::join!(job1, job2);
-
-    match res1 {
-        Ok(len) => log::info!("proxy from server to local end with {} bytes", len),
-        Err(err) => log::error!("proxy from server to local error {err:?}"),
+    match pipeline_streams(incoming_proxy_conn, local_tunnel).await {
+        Ok(res) => {
+            log::info!("sub_connection pipe to local_tunnel stop res {res:?}");
+        }
+        Err(e) => {
+            log::error!("sub_connection pipe to local_tunnel stop err {e:?}");
+        }
     }
-
-    match res2 {
-        Ok(len) => log::info!("proxy from local to server end with {} bytes", len),
-        Err(err) => log::error!("proxy from local to server error {err:?}"),
-    }
-
-    log::info!("sub_connection pipe to local_tunnel stop");
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use futures::{select, AsyncRead, AsyncReadExt, AsyncWrite, FutureExt};
+use futures::{AsyncRead, AsyncWrite};
 use local_tunnel::tcp::LocalTcpTunnel;
-use protocol::cluster::AgentTunnelRequest;
+use protocol::cluster::{wait_object, AgentTunnelRequest};
 
 use crate::local_tunnel::LocalTunnel;
 
@@ -25,7 +25,7 @@ where
     log::info!("sub_connection pipe to local_tunnel start");
     let (mut reader1, mut writer1) = sub_connection.split();
 
-    let local_tunnel = match wait_handshake(&mut reader1).await {
+    let local_tunnel = match wait_object::<_, AgentTunnelRequest, 1000>(&mut reader1).await {
         Ok(handshake) => {
             log::info!(
                 "sub_connection pipe with handshake: tls: {}, {}/{:?} ",
@@ -66,42 +66,17 @@ where
     let job1 = futures::io::copy(&mut reader1, &mut writer2);
     let job2 = futures::io::copy(&mut reader2, &mut writer1);
 
-    select! {
-        e = job1.fuse() => {
-            if let Err(e) = e {
-                log::error!("job1 error: {}", e);
-            }
-        }
-        e = job2.fuse() => {
-            if let Err(e) = e {
-                log::error!("job2 error: {}", e);
-            }
-        }
+    let (res1, res2) = futures::join!(job1, job2);
+
+    match res1 {
+        Ok(len) => log::info!("proxy from server to local end with {} bytes", len),
+        Err(err) => log::error!("proxy from server to local error {err:?}"),
     }
+
+    match res2 {
+        Ok(len) => log::info!("proxy from local to server end with {} bytes", len),
+        Err(err) => log::error!("proxy from local to server error {err:?}"),
+    }
+
     log::info!("sub_connection pipe to local_tunnel stop");
-}
-
-pub async fn wait_handshake<R: AsyncRead + Send + Unpin>(
-    reader: &mut R,
-) -> Result<AgentTunnelRequest, String> {
-    let mut len_buf = [0; 2];
-    let mut data_buf = [0; 1000];
-    reader
-        .read_exact(&mut len_buf)
-        .await
-        .map_err(|e| e.to_string())?;
-    let handshake_len = u16::from_be_bytes([len_buf[0], len_buf[1]]) as usize;
-    log::info!("first pkt size: {}", handshake_len);
-    if handshake_len > data_buf.len() {
-        return Err("Handshake package too big".to_string());
-    }
-
-    reader
-        .read_exact(&mut data_buf[0..handshake_len])
-        .await
-        .map_err(|e| e.to_string())?;
-
-    log::info!("got first pkt with size: {}", handshake_len);
-
-    AgentTunnelRequest::try_from(&data_buf[0..handshake_len]).map_err(|e| e.to_string())
 }

--- a/crates/agent/src/local_tunnel.rs
+++ b/crates/agent/src/local_tunnel.rs
@@ -5,9 +5,7 @@ use futures::{AsyncRead, AsyncWrite};
 pub mod registry;
 pub mod tcp;
 
-pub trait LocalTunnel<R: AsyncRead + Unpin, W: AsyncWrite + Unpin>: Send + Sync {
-    fn split(self) -> (R, W);
-}
+pub trait LocalTunnel: AsyncRead + AsyncWrite + Unpin + Send + Sync {}
 
 pub trait ServiceRegistry {
     fn dest_for(&self, tls: bool, service: Option<u16>, domain: &str) -> Option<SocketAddr>;

--- a/crates/agent/src/local_tunnel/tcp.rs
+++ b/crates/agent/src/local_tunnel/tcp.rs
@@ -16,10 +16,16 @@ pub struct LocalTcpTunnel {
 }
 
 impl LocalTcpTunnel {
-    pub async fn new(dest: SocketAddr) -> Result<Self, Box<dyn Error>> {
+    pub async fn connect(dest: SocketAddr) -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             stream: TcpStream::connect(dest).await?,
         })
+    }
+}
+
+impl From<TcpStream> for LocalTcpTunnel {
+    fn from(stream: TcpStream) -> Self {
+        Self { stream }
     }
 }
 

--- a/crates/agent/src/local_tunnel/tcp.rs
+++ b/crates/agent/src/local_tunnel/tcp.rs
@@ -1,12 +1,15 @@
-use std::{error::Error, net::SocketAddr};
-
-use async_std::net::TcpStream;
-use futures::{
-    io::{ReadHalf, WriteHalf},
-    AsyncReadExt,
+use std::{
+    error::Error,
+    io,
+    net::{Shutdown, SocketAddr},
+    pin::Pin,
+    task::{Context, Poll},
 };
 
 use super::LocalTunnel;
+use async_std::net::TcpStream;
+use futures::{AsyncRead, AsyncWrite};
+use protocol::stream::NamedStream;
 
 pub struct LocalTcpTunnel {
     stream: TcpStream,
@@ -20,8 +23,43 @@ impl LocalTcpTunnel {
     }
 }
 
-impl LocalTunnel<ReadHalf<TcpStream>, WriteHalf<TcpStream>> for LocalTcpTunnel {
-    fn split(self) -> (ReadHalf<TcpStream>, WriteHalf<TcpStream>) {
-        AsyncReadExt::split(self.stream)
+impl LocalTunnel for LocalTcpTunnel {}
+
+impl NamedStream for LocalTcpTunnel {
+    fn name(&self) -> &'static str {
+        "local-tcp-tunnel"
+    }
+}
+
+impl AsyncRead for LocalTcpTunnel {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for LocalTcpTunnel {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        Pin::new(&mut this.stream).poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        // We need to call shutdown here, without it the proxy will stuck forever
+        Poll::Ready(Pin::new(&mut this.stream).shutdown(Shutdown::Write))
     }
 }

--- a/crates/agent/src/main.rs
+++ b/crates/agent/src/main.rs
@@ -6,7 +6,6 @@ use atm0s_reverse_proxy_agent::{
 };
 use base64::{engine::general_purpose::URL_SAFE, Engine as _};
 use clap::Parser;
-use futures::{AsyncRead, AsyncWrite};
 use protocol::{services::SERVICE_RTSP, DEFAULT_TUNNEL_CERT};
 use protocol_ed25519::AgentLocalKey;
 use rustls::pki_types::CertificateDer;
@@ -168,13 +167,11 @@ async fn main() {
     }
 }
 
-pub async fn run_connection_loop<S, R, W>(
-    mut connection: impl Connection<S, R, W>,
+pub async fn run_connection_loop<S>(
+    mut connection: impl Connection<S>,
     registry: Arc<dyn ServiceRegistry>,
 ) where
-    S: SubConnection<R, W> + 'static,
-    R: AsyncRead + Send + Unpin + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
+    S: SubConnection + 'static,
 {
     loop {
         match connection.recv().await {

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -10,3 +10,4 @@ license = "MIT"
 [dependencies]
 serde = { workspace = true, features = ["derive"] }
 bincode = { workspace = true }
+futures = { workspace = true }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -11,3 +11,4 @@ license = "MIT"
 serde = { workspace = true, features = ["derive"] }
 bincode = { workspace = true }
 futures = { workspace = true }
+log = { workspace = true }

--- a/crates/protocol/src/cluster.rs
+++ b/crates/protocol/src/cluster.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ClusterTunnelRequest {
@@ -58,4 +59,51 @@ impl TryFrom<&[u8]> for AgentTunnelRequest {
     fn try_from(buf: &[u8]) -> Result<Self, Self::Error> {
         bincode::deserialize(buf)
     }
+}
+
+pub async fn wait_object<
+    R: AsyncRead + Send + Unpin,
+    O: DeserializeOwned,
+    const MAX_SIZE: usize,
+>(
+    reader: &mut R,
+) -> Result<O, String> {
+    let mut len_buf = [0; 2];
+    let mut data_buf = [0; MAX_SIZE];
+    reader
+        .read_exact(&mut len_buf)
+        .await
+        .map_err(|e| e.to_string())?;
+    let handshake_len = u16::from_be_bytes([len_buf[0], len_buf[1]]) as usize;
+    if handshake_len > data_buf.len() {
+        return Err("Package too big".to_string());
+    }
+
+    reader
+        .read_exact(&mut data_buf[0..handshake_len])
+        .await
+        .map_err(|e| e.to_string())?;
+
+    bincode::deserialize(&data_buf[0..handshake_len]).map_err(|e| e.to_string())
+}
+
+pub async fn write_object<W: AsyncWrite + Send + Unpin, O: Serialize, const MAX_SIZE: usize>(
+    writer: &mut W,
+    object: O,
+) -> Result<(), String> {
+    let data_buf: Vec<u8> = bincode::serialize(&object).expect("Should convert to binary");
+    if data_buf.len() > MAX_SIZE {
+        return Err("Buffer to big".to_string());
+    }
+    let len_buf = (data_buf.len() as u16).to_be_bytes();
+
+    writer
+        .write_all(&len_buf)
+        .await
+        .map_err(|e| e.to_string())?;
+    writer
+        .write_all(&data_buf)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
 }

--- a/crates/protocol/src/lib.rs
+++ b/crates/protocol/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cluster;
 pub mod key;
 pub mod services;
+pub mod stream;
 
 pub const DEFAULT_TUNNEL_CERT: &[u8] = include_bytes!("../certs/tunnel.cert");
 pub const DEFAULT_TUNNEL_KEY: &[u8] = include_bytes!("../certs/tunnel.key");

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -179,7 +179,7 @@ where
                         Poll::Pending => {}
                     }
                 } else if copy_buffer.is_lock_write() {
-                    // we finish then switch to ShutingDonw
+                    // we finish then switch to ShuttingDown
                     log::info!(
                         "[OneDirectCopy {} => {}] write finished after {} bytes => switch to ShuttingDown state",
                         from.name(),

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -22,8 +22,8 @@ pub fn pipeline_streams<
     BidirectCopyStream {
         a,
         b,
-        a_to_b: OneDirectState::Running(CopyBuffer::default()),
-        b_to_a: OneDirectState::Running(CopyBuffer::default()),
+        a_to_b: OneDirectState::Running(Box::default()),
+        b_to_a: OneDirectState::Running(Box::default()),
     }
 }
 
@@ -102,7 +102,7 @@ impl CopyBuffer {
 }
 
 enum OneDirectState {
-    Running(CopyBuffer),
+    Running(Box<CopyBuffer>),
     ShuttingDown(usize),
     Done(usize),
 }
@@ -157,7 +157,7 @@ where
                 }
 
                 let read_buf = copy_buffer.front();
-                if read_buf.len() > 0 {
+                if !read_buf.is_empty() {
                     // we have some data to write
                     match to.as_mut().poll_write(cx, read_buf).map_err(|e| {
                         log::error!(

--- a/crates/protocol/src/stream.rs
+++ b/crates/protocol/src/stream.rs
@@ -1,0 +1,225 @@
+use std::{
+    future::Future,
+    io,
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use futures::{AsyncRead, AsyncWrite};
+
+pub fn pipeline_streams<
+    S1: AsyncRead + AsyncWrite + NamedStream + Unpin,
+    S2: AsyncRead + AsyncWrite + NamedStream + Unpin,
+>(
+    a: S1,
+    b: S2,
+) -> BidirectCopyStream<S1, S2> {
+    log::info!(
+        "Process bidirect-copy between {} <==> {}",
+        a.name(),
+        b.name()
+    );
+    BidirectCopyStream {
+        a,
+        b,
+        a_to_b: OneDirectState::Running(CopyBuffer::default()),
+        b_to_a: OneDirectState::Running(CopyBuffer::default()),
+    }
+}
+
+pub trait NamedStream {
+    fn name(&self) -> &'static str;
+}
+
+const BUFFER_SIZE: usize = 4096;
+const BUFFER_WRITE_MIN: usize = 100;
+
+#[derive(Clone)]
+struct CopyBuffer {
+    buf: [u8; BUFFER_SIZE],
+    front_pos: usize,
+    back_pos: usize,
+    sum: usize,
+    lock_write: bool,
+}
+
+impl Default for CopyBuffer {
+    fn default() -> Self {
+        Self {
+            buf: [0; BUFFER_SIZE],
+            front_pos: 0,
+            back_pos: 0,
+            sum: 0,
+            lock_write: false,
+        }
+    }
+}
+
+impl CopyBuffer {
+    fn lock_write(&mut self) {
+        self.lock_write = true;
+    }
+
+    fn is_lock_write(&self) -> bool {
+        self.lock_write
+    }
+
+    fn front(&self) -> &[u8] {
+        &self.buf[self.front_pos..self.back_pos]
+    }
+
+    pub fn move_front(&mut self, len: usize) {
+        assert!(
+            self.front_pos + len <= self.back_pos,
+            "should not read more data than it"
+        );
+        self.front_pos += len;
+        self.sum += len;
+
+        if self.front_pos == self.back_pos {
+            self.front_pos = 0;
+            self.back_pos = 0;
+        }
+    }
+
+    fn back_mut(&mut self) -> &mut [u8] {
+        if self.lock_write {
+            //if in lock_write then we return empty buf
+            &mut self.buf[..0]
+        } else {
+            &mut self.buf[self.back_pos..]
+        }
+    }
+
+    fn move_back(&mut self, len: usize) {
+        assert!(
+            self.back_pos + len <= self.buf.len(),
+            "should not append more data than space"
+        );
+        self.back_pos += len;
+        self.sum += len;
+    }
+}
+
+enum OneDirectState {
+    Running(CopyBuffer),
+    ShuttingDown(usize),
+    Done(usize),
+}
+
+fn process_one_direct<F, T>(
+    cx: &mut Context<'_>,
+    from: &mut F,
+    to: &mut T,
+    state: &mut OneDirectState,
+) -> Poll<io::Result<usize>>
+where
+    F: AsyncRead + AsyncWrite + NamedStream + Unpin,
+    T: AsyncRead + AsyncWrite + NamedStream + Unpin,
+{
+    let mut from = Pin::new(from);
+    let mut to = Pin::new(to);
+
+    loop {
+        match state {
+            OneDirectState::Running(copy_buffer) => {
+                let write_buf = copy_buffer.back_mut();
+                if write_buf.len() >= BUFFER_WRITE_MIN {
+                    //only write if we have big enough space
+                    match from.as_mut().poll_read(cx, write_buf)? {
+                        Poll::Ready(0) => {
+                            log::info!(
+                                "[OneDirectCopy {} => {}] read finished => lock_write",
+                                from.name(),
+                                to.name()
+                            );
+                            //read stream closed => lock write
+                            copy_buffer.lock_write();
+                        }
+                        Poll::Ready(len) => {
+                            copy_buffer.move_back(len);
+                            log::info!(
+                                "[OneDirectCopy {} => {}] read {len} bytes, current buf {} bytes",
+                                from.name(),
+                                to.name(),
+                                copy_buffer.front().len()
+                            );
+                        }
+                        Poll::Pending => {}
+                    }
+                }
+
+                let read_buf = copy_buffer.front();
+                if read_buf.len() > 0 {
+                    // we have some data to write
+                    match to.as_mut().poll_write(cx, read_buf)? {
+                        Poll::Ready(len) => {
+                            copy_buffer.move_front(len);
+                            log::info!(
+                                "[OneDirectCopy {} => {}] write {len} bytes, current buf {} bytes",
+                                from.name(),
+                                to.name(),
+                                copy_buffer.front().len()
+                            );
+                        }
+                        Poll::Pending => {}
+                    }
+                } else if copy_buffer.is_lock_write() {
+                    // we finish then switch to ShutingDonw
+                    log::info!(
+                        "[OneDirectCopy {} => {}] write finished after {} bytes => switch to ShuttingDown state",
+                        from.name(),
+                        to.name(),
+                        copy_buffer.sum
+                    );
+                    *state = OneDirectState::ShuttingDown(copy_buffer.sum)
+                } else {
+                    return Poll::Pending;
+                }
+            }
+            OneDirectState::ShuttingDown(sum) => {
+                ready!(to.as_mut().poll_flush(cx))?;
+                log::info!(
+                    "[OneDirectCopy {} => {}] write finished flush",
+                    from.name(),
+                    to.name(),
+                );
+                ready!(to.as_mut().poll_close(cx))?;
+                log::info!(
+                    "[OneDirectCopy {} => {}] write finished close => Done",
+                    from.name(),
+                    to.name(),
+                );
+                *state = OneDirectState::Done(*sum)
+            }
+            OneDirectState::Done(sum) => return Poll::Ready(Ok(*sum)),
+        }
+    }
+}
+
+pub struct BidirectCopyStream<S1, S2> {
+    a: S1,
+    b: S2,
+    a_to_b: OneDirectState,
+    b_to_a: OneDirectState,
+}
+
+impl<
+        S1: AsyncRead + AsyncWrite + NamedStream + Unpin,
+        S2: AsyncRead + AsyncWrite + NamedStream + Unpin,
+    > Future for BidirectCopyStream<S1, S2>
+{
+    type Output = Result<(usize, usize), std::io::Error>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        let res1 = process_one_direct(cx, &mut this.a, &mut this.b, &mut this.a_to_b)?;
+        let res2 = process_one_direct(cx, &mut this.b, &mut this.a, &mut this.b_to_a)?;
+
+        let a_to_b = ready!(res1);
+        let b_to_a = ready!(res2);
+
+        Poll::Ready(Ok((a_to_b, b_to_a)))
+    }
+}

--- a/crates/relayer/Cargo.toml
+++ b/crates/relayer/Cargo.toml
@@ -26,6 +26,7 @@ rustls = { workspace = true, features = ["ring", "std"] }
 atm0s-sdn = { workspace = true }
 rtsp-types = { workspace = true }
 local-ip-address = { workspace = true }
+derive_more = { workspace = true, features = ["from"] }
 
 [features]
 default = ["binary"]

--- a/crates/relayer/src/agent_listener.rs
+++ b/crates/relayer/src/agent_listener.rs
@@ -29,6 +29,7 @@ pub trait AgentListener<C: AgentConnection<S>, S: AgentSubConnection> {
 pub trait AgentConnectionHandler<S: AgentSubConnection + Send + Sync>:
     Send + Sync + Clone + 'static
 {
+    fn name(&self) -> &str;
     fn handle(
         &self,
         agent_domain: &str,
@@ -57,6 +58,10 @@ impl<S: AgentSubConnection> Default for AgentIncomingConnHandlerDummy<S> {
 }
 
 impl<S: AgentSubConnection> AgentConnectionHandler<S> for AgentIncomingConnHandlerDummy<S> {
+    fn name(&self) -> &str {
+        "dummy"
+    }
+
     async fn handle(&self, agent_domain: &str, _connection: S) -> Result<(), Box<dyn Error>> {
         log::info!("on connection from agent {}", agent_domain);
         Ok(())

--- a/crates/relayer/src/agent_listener.rs
+++ b/crates/relayer/src/agent_listener.rs
@@ -42,7 +42,7 @@ pub struct AgentIncomingConnHandlerDummy<S: AgentSubConnection> {
 impl<S: AgentSubConnection> Clone for AgentIncomingConnHandlerDummy<S> {
     fn clone(&self) -> Self {
         Self {
-            _phantom: self._phantom.clone(),
+            _phantom: self._phantom,
         }
     }
 }

--- a/crates/relayer/src/agent_listener/quic.rs
+++ b/crates/relayer/src/agent_listener/quic.rs
@@ -166,6 +166,9 @@ impl AsyncRead for AgentQuicSubConnection {
     ) -> Poll<std::io::Result<usize>> {
         let this = self.get_mut();
         match this.recv.poll_read(cx, buf) {
+            // TODO refactor
+            // Quinn seems to have some issue with close connection. the Writer side already close but
+            // Reader side only fire bellow error
             Poll::Ready(Err(quinn::ReadError::ConnectionLost(
                 ConnectionError::ConnectionClosed(_),
             ))) => Poll::Ready(Ok(0)),

--- a/crates/relayer/src/agent_listener/quic.rs
+++ b/crates/relayer/src/agent_listener/quic.rs
@@ -179,7 +179,7 @@ impl AsyncRead for AgentQuicSubConnection {
             // Quinn seems to have some issue with close connection. the Writer side already close but
             // Reader side only fire bellow error
             Poll::Ready(Err(quinn::ReadError::ConnectionLost(
-                ConnectionError::ConnectionClosed(_),
+                ConnectionError::ApplicationClosed(_),
             ))) => Poll::Ready(Ok(0)),
             e => e.map_err(|e| e.into()),
         }

--- a/crates/relayer/src/agent_store.rs
+++ b/crates/relayer/src/agent_store.rs
@@ -5,23 +5,23 @@ use std::{
 
 use async_std::channel::Sender;
 
-use crate::ProxyTunnel;
+use crate::proxy_listener::ProxyTunnelWrap;
 
 #[derive(Clone, Default)]
 pub struct AgentStore {
     #[allow(clippy::type_complexity)]
-    agents: Arc<RwLock<HashMap<u64, Sender<Box<dyn ProxyTunnel>>>>>,
+    agents: Arc<RwLock<HashMap<u64, Sender<ProxyTunnelWrap>>>>,
 }
 
 impl AgentStore {
-    pub fn add(&self, id: u64, tx: Sender<Box<dyn ProxyTunnel>>) {
+    pub fn add(&self, id: u64, tx: Sender<ProxyTunnelWrap>) {
         self.agents
             .write()
             .expect("Should write agents")
             .insert(id, tx);
     }
 
-    pub fn get(&self, id: u64) -> Option<Sender<Box<dyn ProxyTunnel>>> {
+    pub fn get(&self, id: u64) -> Option<Sender<ProxyTunnelWrap>> {
         self.agents
             .read()
             .expect("Should write agents")

--- a/crates/relayer/src/agent_worker.rs
+++ b/crates/relayer/src/agent_worker.rs
@@ -1,15 +1,12 @@
-use std::{error::Error, marker::PhantomData, sync::Arc, time::Instant};
+use std::{error::Error, marker::PhantomData, time::Instant};
 
-use futures::{select, AsyncRead, AsyncWrite, AsyncWriteExt, FutureExt};
+use futures::{select, AsyncWriteExt, FutureExt};
 use metrics::{counter, gauge, histogram};
+use protocol::stream::pipeline_streams;
 
-enum IncomingConn<
-    S: AgentSubConnection<R, W>,
-    R: AsyncRead + Send + Unpin,
-    W: AsyncWrite + Send + Unpin,
-> {
-    FromProxy(Box<dyn ProxyTunnel>),
-    FromAgent(S, PhantomData<(R, W)>),
+enum IncomingConn<P: ProxyTunnel, S: AgentSubConnection> {
+    FromProxy(P),
+    FromAgent(S),
 }
 
 use crate::{
@@ -21,30 +18,27 @@ use crate::{
     METRICS_TUNNEL_AGENT_HISTOGRAM, METRICS_TUNNEL_AGENT_LIVE,
 };
 
-pub struct AgentWorker<AG, S, R, W>
+pub struct AgentWorker<AG, P, S, H>
 where
-    AG: AgentConnection<S, R, W>,
-    S: AgentSubConnection<R, W>,
-    R: AsyncRead + Unpin,
-    W: AsyncWrite + Unpin,
+    AG: AgentConnection<S>,
+    P: ProxyTunnel,
+    S: AgentSubConnection,
+    H: AgentConnectionHandler<S>,
 {
-    _tmp: PhantomData<(S, R, W)>,
+    _tmp: PhantomData<S>,
     connection: AG,
-    rx: async_std::channel::Receiver<Box<dyn ProxyTunnel>>,
-    incoming_conn_handler: Arc<dyn AgentConnectionHandler<S, R, W>>,
+    rx: async_std::channel::Receiver<P>,
+    incoming_conn_handler: H,
 }
 
-impl<AG, S, R, W> AgentWorker<AG, S, R, W>
+impl<AG, P, S, H> AgentWorker<AG, P, S, H>
 where
-    AG: AgentConnection<S, R, W>,
-    S: AgentSubConnection<R, W> + 'static,
-    R: AsyncRead + Send + Unpin + 'static,
-    W: AsyncWrite + Send + Unpin + 'static,
+    AG: AgentConnection<S>,
+    P: ProxyTunnel,
+    S: AgentSubConnection,
+    H: AgentConnectionHandler<S>,
 {
-    pub fn new(
-        connection: AG,
-        incoming_conn_handler: Arc<dyn AgentConnectionHandler<S, R, W>>,
-    ) -> (Self, async_std::channel::Sender<Box<dyn ProxyTunnel>>) {
+    pub fn new(connection: AG, incoming_conn_handler: H) -> (Self, async_std::channel::Sender<P>) {
         let (tx, rx) = async_std::channel::bounded(3);
         (
             Self {
@@ -57,25 +51,22 @@ where
         )
     }
 
-    async fn handle_proxy_tunnel(
-        &mut self,
-        mut conn: Box<dyn ProxyTunnel>,
-    ) -> Result<(), Box<dyn Error>> {
+    async fn handle_proxy_tunnel(&mut self, proxy_tunnel_conn: P) -> Result<(), Box<dyn Error>> {
         counter!(METRICS_TUNNEL_AGENT_COUNT).increment(1);
         let started = Instant::now();
-        let sub_connection = self.connection.create_sub_connection().await?;
+        let mut to_agent_conn = self.connection.create_sub_connection().await?;
 
         async_std::task::spawn(async move {
-            let domain = conn.domain().to_string();
-            let (mut reader1, mut writer1) = sub_connection.split();
-            let handshake = conn.handshake();
-            let err1 = writer1
+            let is_local = proxy_tunnel_conn.local();
+            let domain = proxy_tunnel_conn.domain().to_string();
+            let handshake = proxy_tunnel_conn.handshake();
+            let err1 = to_agent_conn
                 .write_all(&(handshake.len() as u16).to_be_bytes())
                 .await;
-            let err2 = writer1.write_all(handshake).await;
+            let err2 = to_agent_conn.write_all(handshake).await;
             if let Err(e) = err1.and(err2) {
                 log::error!("handshake for domain {domain} failed {:?}", e);
-                if conn.local() {
+                if is_local {
                     gauge!(METRICS_PROXY_HTTP_ERROR_COUNT).increment(1.0);
                 } else {
                     gauge!(METRICS_PROXY_CLUSTER_ERROR_COUNT).increment(1.0);
@@ -85,32 +76,24 @@ where
             histogram!(METRICS_TUNNEL_AGENT_HISTOGRAM)
                 .record(started.elapsed().as_millis() as f32 / 1000.0);
 
-            if conn.local() {
+            if is_local {
                 gauge!(METRICS_PROXY_HTTP_LIVE).increment(1.0);
             } else {
                 gauge!(METRICS_PROXY_CLUSTER_LIVE).increment(1.0);
             }
             gauge!(METRICS_TUNNEL_AGENT_LIVE).increment(1.0);
             log::info!("start proxy tunnel for domain {domain}");
-            let (mut reader2, mut writer2) = conn.split();
 
-            let job1 = futures::io::copy(&mut reader1, &mut writer2);
-            let job2 = futures::io::copy(&mut reader2, &mut writer1);
-
-            let (res1, res2) = futures::join!(job1, job2);
-
-            match res1 {
-                Ok(len) => log::info!("proxy from client to server end with {} bytes", len),
-                Err(err) => log::error!("proxy from client to server error {err:?}"),
+            match pipeline_streams(proxy_tunnel_conn, to_agent_conn).await {
+                Ok(res) => {
+                    log::info!("end proxy tunnel for domain {domain}, res {res:?}");
+                }
+                Err(e) => {
+                    log::error!("end proxy tunnel for domain {domain} err {e:?}");
+                }
             }
 
-            match res2 {
-                Ok(len) => log::info!("proxy from server to client end with {} bytes", len),
-                Err(err) => log::error!("proxy from server to client error {err:?}"),
-            }
-
-            log::info!("end proxy tunnel for domain {}", domain);
-            if conn.local() {
+            if is_local {
                 gauge!(METRICS_PROXY_HTTP_LIVE).decrement(1.0);
             } else {
                 gauge!(METRICS_PROXY_CLUSTER_LIVE).decrement(1.0);
@@ -138,7 +121,7 @@ where
     pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
         let incoming = select! {
             conn = self.rx.recv().fuse() => IncomingConn::FromProxy(conn?),
-            conn = self.connection.recv().fuse() => IncomingConn::FromAgent(conn?, Default::default()),
+            conn = self.connection.recv().fuse() => IncomingConn::FromAgent(conn?),
         };
 
         match incoming {
@@ -148,7 +131,7 @@ where
                     counter!(METRICS_TUNNEL_AGENT_ERROR_COUNT).increment(1);
                 }
             }
-            IncomingConn::FromAgent(conn, _) => {
+            IncomingConn::FromAgent(conn) => {
                 if let Err(e) = self.handle_agent_connection(conn).await {
                     log::error!("handle agent connection error {:?}", e);
                     counter!(METRICS_PROXY_AGENT_ERROR_COUNT).increment(1);

--- a/crates/relayer/src/agent_worker.rs
+++ b/crates/relayer/src/agent_worker.rs
@@ -109,6 +109,7 @@ where
         let domain = self.connection.domain();
         async_std::task::spawn(async move {
             gauge!(METRICS_PROXY_AGENT_LIVE).increment(1.0);
+            log::info!("handle agent connection with external logic");
             if let Err(e) = handler.handle(&domain, conn).await {
                 counter!(METRICS_PROXY_AGENT_ERROR_COUNT).increment(1);
                 log::error!("handle agent connection error {:?}", e);
@@ -126,12 +127,14 @@ where
 
         match incoming {
             IncomingConn::FromProxy(conn) => {
+                log::info!("incoming connect request from proxy {}", conn.name());
                 if let Err(e) = self.handle_proxy_tunnel(conn).await {
                     log::error!("handle proxy tunnel error {:?}", e);
                     counter!(METRICS_TUNNEL_AGENT_ERROR_COUNT).increment(1);
                 }
             }
             IncomingConn::FromAgent(conn) => {
+                log::info!("incoming connect request from client {}", conn.name());
                 if let Err(e) = self.handle_agent_connection(conn).await {
                     log::error!("handle agent connection error {:?}", e);
                     counter!(METRICS_PROXY_AGENT_ERROR_COUNT).increment(1);

--- a/crates/relayer/src/lib.rs
+++ b/crates/relayer/src/lib.rs
@@ -55,7 +55,7 @@ pub use proxy_listener::cluster::{
 };
 pub use quinn;
 
-pub use proxy_listener::cluster::{run_sdn, ProxyClusterIncommingTunnel, ProxyClusterListener};
+pub use proxy_listener::cluster::{run_sdn, ProxyClusterIncomingTunnel, ProxyClusterListener};
 pub use proxy_listener::tcp::{ProxyTcpListener, ProxyTcpTunnel};
 pub use proxy_listener::{ProxyListener, ProxyTunnel};
 

--- a/crates/relayer/src/main.rs
+++ b/crates/relayer/src/main.rs
@@ -286,8 +286,8 @@ async fn main() {
     )
     .await;
 
-    let agent_rpc_handler_quic = Arc::new(AgentIncomingConnHandlerDummy::default());
-    let agent_rpc_handler_tcp = Arc::new(AgentIncomingConnHandlerDummy::default());
+    let agent_rpc_handler_quic = AgentIncomingConnHandlerDummy::default();
+    let agent_rpc_handler_tcp = AgentIncomingConnHandlerDummy::default();
 
     loop {
         select! {

--- a/crates/relayer/src/proxy_listener.rs
+++ b/crates/relayer/src/proxy_listener.rs
@@ -7,7 +7,7 @@ use futures::{AsyncRead, AsyncWrite};
 use protocol::stream::NamedStream;
 use tcp::ProxyTcpTunnel;
 
-use crate::ProxyClusterIncommingTunnel;
+use crate::ProxyClusterIncomingTunnel;
 
 pub mod cluster;
 pub mod tcp;
@@ -35,7 +35,7 @@ pub trait ProxyListener: Send + Sync {
 #[derive(From)]
 pub enum ProxyTunnelWrap {
     Tcp(ProxyTcpTunnel),
-    Cluster(ProxyClusterIncommingTunnel),
+    Cluster(ProxyClusterIncomingTunnel),
 }
 
 impl ProxyTunnel for ProxyTunnelWrap {

--- a/crates/relayer/src/proxy_listener.rs
+++ b/crates/relayer/src/proxy_listener.rs
@@ -1,6 +1,13 @@
 //! Proxy is a server which accept connections from users and forward them to the target agent.
 
+use std::pin::Pin;
+
+use derive_more::derive::From;
 use futures::{AsyncRead, AsyncWrite};
+use protocol::stream::NamedStream;
+use tcp::ProxyTcpTunnel;
+
+use crate::ProxyClusterIncommingTunnel;
 
 pub mod cluster;
 pub mod tcp;
@@ -10,22 +17,115 @@ pub trait DomainDetector: Send + Sync {
     fn get_domain(&self, buf: &[u8]) -> Option<String>;
 }
 
-#[async_trait::async_trait]
-pub trait ProxyTunnel: Send + Sync {
-    async fn wait(&mut self) -> Option<()>;
+pub trait ProxyTunnel:
+    AsyncRead + AsyncWrite + NamedStream + Send + Sync + Unpin + 'static
+{
+    fn wait(&mut self) -> impl std::future::Future<Output = Option<()>> + Send;
     fn source_addr(&self) -> String;
     fn local(&self) -> bool;
     fn domain(&self) -> &str;
     fn handshake(&self) -> &[u8];
-    fn split(
-        &mut self,
-    ) -> (
-        Box<dyn AsyncRead + Send + Sync + Unpin>,
-        Box<dyn AsyncWrite + Send + Sync + Unpin>,
-    );
 }
 
-#[async_trait::async_trait]
 pub trait ProxyListener: Send + Sync {
-    async fn recv(&mut self) -> Option<Box<dyn ProxyTunnel>>;
+    type Stream;
+    fn recv(&mut self) -> impl std::future::Future<Output = Option<Self::Stream>> + Send;
+}
+
+#[derive(From)]
+pub enum ProxyTunnelWrap {
+    Tcp(ProxyTcpTunnel),
+    Cluster(ProxyClusterIncommingTunnel),
+}
+
+impl ProxyTunnel for ProxyTunnelWrap {
+    async fn wait(&mut self) -> Option<()> {
+        match self {
+            ProxyTunnelWrap::Tcp(inner) => inner.wait().await,
+            ProxyTunnelWrap::Cluster(inner) => inner.wait().await,
+        }
+    }
+
+    fn source_addr(&self) -> String {
+        match self {
+            ProxyTunnelWrap::Tcp(inner) => inner.source_addr(),
+            ProxyTunnelWrap::Cluster(inner) => inner.source_addr(),
+        }
+    }
+
+    fn local(&self) -> bool {
+        match self {
+            ProxyTunnelWrap::Tcp(inner) => inner.local(),
+            ProxyTunnelWrap::Cluster(inner) => inner.local(),
+        }
+    }
+
+    fn domain(&self) -> &str {
+        match self {
+            ProxyTunnelWrap::Tcp(inner) => inner.domain(),
+            ProxyTunnelWrap::Cluster(inner) => inner.domain(),
+        }
+    }
+
+    fn handshake(&self) -> &[u8] {
+        match self {
+            ProxyTunnelWrap::Tcp(inner) => inner.handshake(),
+            ProxyTunnelWrap::Cluster(inner) => inner.handshake(),
+        }
+    }
+}
+
+impl NamedStream for ProxyTunnelWrap {
+    fn name(&self) -> &'static str {
+        match self {
+            ProxyTunnelWrap::Tcp(inner) => inner.name(),
+            ProxyTunnelWrap::Cluster(inner) => inner.name(),
+        }
+    }
+}
+
+impl AsyncRead for ProxyTunnelWrap {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut [u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            ProxyTunnelWrap::Tcp(inner) => Pin::new(inner).poll_read(cx, buf),
+            ProxyTunnelWrap::Cluster(inner) => Pin::new(inner).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for ProxyTunnelWrap {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        match self.get_mut() {
+            ProxyTunnelWrap::Tcp(inner) => Pin::new(inner).poll_write(cx, buf),
+            ProxyTunnelWrap::Cluster(inner) => Pin::new(inner).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ProxyTunnelWrap::Tcp(inner) => Pin::new(inner).poll_flush(cx),
+            ProxyTunnelWrap::Cluster(inner) => Pin::new(inner).poll_flush(cx),
+        }
+    }
+
+    fn poll_close(
+        self: Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        match self.get_mut() {
+            ProxyTunnelWrap::Tcp(inner) => Pin::new(inner).poll_close(cx),
+            ProxyTunnelWrap::Cluster(inner) => Pin::new(inner).poll_close(cx),
+        }
+    }
 }

--- a/crates/relayer/src/proxy_listener/cluster.rs
+++ b/crates/relayer/src/proxy_listener/cluster.rs
@@ -225,11 +225,11 @@ impl ProxyClusterListener {
 }
 
 impl ProxyListener for ProxyClusterListener {
-    type Stream = ProxyClusterIncommingTunnel;
+    type Stream = ProxyClusterIncomingTunnel;
     async fn recv(&mut self) -> Option<Self::Stream> {
         let connecting = self.server.accept().await?;
         log::info!("incoming connection from {}", connecting.remote_address());
-        Some(ProxyClusterIncommingTunnel {
+        Some(ProxyClusterIncomingTunnel {
             virtual_addr: connecting.remote_address(),
             domain: "".to_string(),
             handshake: vec![],
@@ -241,7 +241,7 @@ impl ProxyListener for ProxyClusterListener {
     }
 }
 
-pub struct ProxyClusterIncommingTunnel {
+pub struct ProxyClusterIncomingTunnel {
     virtual_addr: SocketAddr,
     domain: String,
     handshake: Vec<u8>,
@@ -251,7 +251,7 @@ pub struct ProxyClusterIncommingTunnel {
     wait_stream_write: Option<Waker>,
 }
 
-impl ProxyTunnel for ProxyClusterIncommingTunnel {
+impl ProxyTunnel for ProxyClusterIncomingTunnel {
     fn source_addr(&self) -> String {
         format!("sdn-quic://{}", self.virtual_addr)
     }
@@ -298,13 +298,13 @@ impl ProxyTunnel for ProxyClusterIncommingTunnel {
     }
 }
 
-impl NamedStream for ProxyClusterIncommingTunnel {
+impl NamedStream for ProxyClusterIncomingTunnel {
     fn name(&self) -> &'static str {
         "proxy-sdn-quic-tunnel"
     }
 }
 
-impl AsyncRead for ProxyClusterIncommingTunnel {
+impl AsyncRead for ProxyClusterIncomingTunnel {
     fn poll_read(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -329,7 +329,7 @@ impl AsyncRead for ProxyClusterIncommingTunnel {
     }
 }
 
-impl AsyncWrite for ProxyClusterIncommingTunnel {
+impl AsyncWrite for ProxyClusterIncomingTunnel {
     fn poll_write(
         self: Pin<&mut Self>,
         cx: &mut Context<'_>,

--- a/crates/relayer/src/proxy_listener/cluster.rs
+++ b/crates/relayer/src/proxy_listener/cluster.rs
@@ -317,7 +317,7 @@ impl AsyncRead for ProxyClusterIncomingTunnel {
                 // Quinn seems to have some issue with close connection. the Writer side already close but
                 // Reader side only fire bellow error
                 Poll::Ready(Err(quinn::ReadError::ConnectionLost(
-                    ConnectionError::ConnectionClosed(_),
+                    ConnectionError::ApplicationClosed(_),
                 ))) => Poll::Ready(Ok(0)),
                 e => e.map_err(|e| e.into()),
             },
@@ -415,7 +415,7 @@ impl AsyncRead for ProxyClusterOutgoingTunnel {
             // Quinn seems to have some issue with close connection. the Writer side already close but
             // Reader side only fire bellow error
             Poll::Ready(Err(quinn::ReadError::ConnectionLost(
-                ConnectionError::ConnectionClosed(_),
+                ConnectionError::ApplicationClosed(_),
             ))) => Poll::Ready(Ok(0)),
             e => e.map_err(|e| e.into()),
         }

--- a/crates/relayer/src/proxy_listener/cluster.rs
+++ b/crates/relayer/src/proxy_listener/cluster.rs
@@ -313,6 +313,9 @@ impl AsyncRead for ProxyClusterIncommingTunnel {
         let this = self.get_mut();
         match this.streams {
             Some((ref mut read, _)) => match read.poll_read(cx, buf) {
+                // TODO refactor
+                // Quinn seems to have some issue with close connection. the Writer side already close but
+                // Reader side only fire bellow error
                 Poll::Ready(Err(quinn::ReadError::ConnectionLost(
                     ConnectionError::ConnectionClosed(_),
                 ))) => Poll::Ready(Ok(0)),
@@ -408,6 +411,9 @@ impl AsyncRead for ProxyClusterOutgoingTunnel {
     ) -> Poll<io::Result<usize>> {
         let this = self.get_mut();
         match this.recv.poll_read(cx, buf) {
+            // TODO refactor
+            // Quinn seems to have some issue with close connection. the Writer side already close but
+            // Reader side only fire bellow error
             Poll::Ready(Err(quinn::ReadError::ConnectionLost(
                 ConnectionError::ConnectionClosed(_),
             ))) => Poll::Ready(Ok(0)),

--- a/crates/relayer/src/proxy_listener/tcp.rs
+++ b/crates/relayer/src/proxy_listener/tcp.rs
@@ -92,6 +92,10 @@ impl ProxyTunnel for ProxyTcpTunnel {
             "[ProxyTcpTunnel] read {} bytes for determine url",
             first_pkt_size
         );
+        if first_pkt_size == 0 {
+            log::warn!("[ProxyTcpTunnel] connect close without data");
+            return None;
+        }
         self.domain = self.detector.get_domain(&first_pkt[..first_pkt_size])?;
         log::info!("[ProxyTcpTunnel] detected domain {}", self.domain);
         self.handshake = (&AgentTunnelRequest {


### PR DESCRIPTION
sometime bi-direct io-copy is unsuccessful. The main reason is:

- missing wait two direct should completed
- async-io lib don't process AsyncWriter.poll_close correct

This PR refactor streams implement and implement a custom version base on tokio::io::bidirection_copy